### PR TITLE
Adding DextrAquario

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Dextra is a Software development company which is really proud of the great work
 <h1>Flutter <img style="margin: 4px 0 0 4px" height="32" src="media/flutter.svg" alt="Flutter Logo"/></h1>
 
  - [Dashbook](https://github.com/erickzanardo/dashbook) - Documentation and sandbox tool for Flutter. Author: [Erick Zanardo](https://github.com/erickzanardo/)
+ - [DextrAquario](https://github.com/dextra/dextraquario) - Platform to hold contribution competitions written with Flutter and Flame for web. Co-Author: [Erick Zanardo](https://github.com/erickzanardo/) | Co-Author [Tyemy Kuga](https://github.com/tyemykuga)
+
  - [Flame](https://github.com/flame-engine/flame) - A game engine written on top of Flutter. Maintainer: [Erick Zanardo](https://github.com/erickzanardo/)
 
 <h1>Javascript <img style="margin: 4px 0 0 4px" height="32" src="media/javascript.svg" alt="Javascript Logo"/></h1>
@@ -45,7 +47,7 @@ Dextra is a Software development company which is really proud of the great work
 
 <h1>Swift <img style="margin: 4px 0 0 4px" height="32" src="media/swift.svg" alt="Swift Logo"/></h1>
 
-- [BricksAndTiles](https://github.com/mugbug/BricksAndTiles) - 
+- [BricksAndTiles](https://github.com/mugbug/BricksAndTiles) -
 🧱 A composable solution for building reusable lists in Swift/UIKit. As easy as playing with Legos. Co-Author/Maintainer: [Pedro Zaroni](https://github.com/mugbug)
 
 <h1>Typescript <img style="margin: 4px 0 0 4px" height="32" src="media/typescript.svg" alt="Typescript Logo"/></h1>

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Dextra is a Software development company which is really proud of the great work
 <h1>Flutter <img style="margin: 4px 0 0 4px" height="32" src="media/flutter.svg" alt="Flutter Logo"/></h1>
 
  - [Dashbook](https://github.com/erickzanardo/dashbook) - Documentation and sandbox tool for Flutter. Author: [Erick Zanardo](https://github.com/erickzanardo/)
- - [DextrAquario](https://github.com/dextra/dextraquario) - Platform to hold contribution competitions written with Flutter and Flame for web. Co-Author: [Erick Zanardo](https://github.com/erickzanardo/) | Co-Author [Tyemy Kuga](https://github.com/tyemykuga)
+ - [DextrAquario](https://github.com/dextra/dextraquario) - Platform to hold contribution competitions written with Flutter and Flame for web. Co-Author: [Erick Zanardo](https://github.com/erickzanardo/), Co-Author [Tyemy Kuga](https://github.com/tyemykuga)
 
  - [Flame](https://github.com/flame-engine/flame) - A game engine written on top of Flutter. Maintainer: [Erick Zanardo](https://github.com/erickzanardo/)
 


### PR DESCRIPTION
Adding DextrAquario.

On this entry, there is one case that we didn't anticipated: When two personnel from Dextra have created the project, making them, both co authors.

So here I include my suggestion to handle this case: List both, separated by a `|`. Let me know what do you think if this is fine.